### PR TITLE
修复了<input>没有显示为文本的问题和数据结构文章中一处笔误

### DIFF
--- a/data_structure.md
+++ b/data_structure.md
@@ -75,7 +75,7 @@ irb(main):016:0> my_hash[:age]
 
 ```
 keys  , 返回所有的keys,
-key?  ,  来判断, 某个字符串, 是否是该hash的可以
+key?  ,  来判断, 某个字符串, 是否是该hash的key
 ```
 
 所有的key, 都是完全不一样的. 不会出现 重复的key.

--- a/rails_steps.md
+++ b/rails_steps.md
@@ -83,7 +83,7 @@ rails的特性的炫耀, 上来就给出一堆花里胡哨的概念和技巧, �
 rails中的各种form_for, form_tag, form_helpers的.  所以,这里我们要向大家展开一扇新的大门.
 学会了form object, 那么 java 世界的第一个框架 struts 就基本学到手了.
 
-然后是 form helpers. 它是把 <input>, <select> 等表单标签使用rails的形式来表示的组件. 这里的
+然后是 form helpers. 它是把 &lt;input>, &lt;select> 等表单标签使用rails的形式来表示的组件. 这里的
 前提知识是 html form 标签. 知道了这个, 就知道如何使用了.
 
 最后,就是如何在controller中读取request中传递过来的参数(往往是 form object的形式).


### PR DESCRIPTION
## 概要

1.  修正了数据结构一文中的一处笔误
2. 修复正了rails学习过程一文中的以下问题

### 问题：

rails学习过程的文章中<input>和<select>被当作html标签显示在文章中，如图：  

![input](https://user-images.githubusercontent.com/42347370/68545290-87a0d200-0406-11ea-8a2a-968fc4d20630.png)

<img src="https://i.loli.net/2019/11/10/bkTZlYKPDEzHhCJ.png" />

[https://i.loli.net/2019/11/10/bkTZlYKPDEzHhCJ.png](https://i.loli.net/2019/11/10/bkTZlYKPDEzHhCJ.png)  
<br>
#### 解决方案  


将每个标签的`<` 替换成 `&lt;`  